### PR TITLE
Add licenses to bintrayUpload first case scenario

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 }
 
 group 'com.saantiaguilera.gradle.publish.helper'
-version '2.0.1'
+version '2.0.2'
 
 publishGlobalConfigurations {
     groupId = group

--- a/core/src/main/groovy/com/saantiaguilera/gradle/publish/helper/PublishHelperPlugin.groovy
+++ b/core/src/main/groovy/com/saantiaguilera/gradle/publish/helper/PublishHelperPlugin.groovy
@@ -125,6 +125,7 @@ public class PublishHelperPlugin implements Plugin<Project> {
                     packageWebsiteUrl = configHelper.url
                     versionName = "${proj.version}"
                     packagePublicDownloadNumbers = false
+                    packageLicenses = [ configHelper.licenseName ]
                 }
 
                 proj.pom {


### PR DESCRIPTION
## Description 

If theres no repository created in bintray for the module and we want a license, bintrayUpload asks us for an extra field. We are adding it.